### PR TITLE
Qt 5.11 beta: CMakeLists.txt: Fix FTBFS (dropping qt5_use_modules)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,11 +66,9 @@ add_executable(${PROJECT_NAME}
    ${QM_LOADER}
 )
 
-qt5_use_modules(lxqt-connman-applet Core Widgets DBus)
-
-
 target_link_libraries(${PROJECT_NAME} 
                       lxqt
+                      Qt5::Core
                       Qt5::Widgets 
                       Qt5::DBus 
                       Qt5::Svg)

--- a/iconviewer/CMakeLists.txt
+++ b/iconviewer/CMakeLists.txt
@@ -36,11 +36,9 @@ add_executable(${PROJECT_NAME}
    ${QRCS_GENERATED}
 )
 
-qt5_use_modules(icon-viewer Core Widgets)
-
-
 target_link_libraries(${PROJECT_NAME} 
                       lxqt
+                      Qt5::Core
                       Qt5::Widgets 
                       Qt5::Svg)
 


### PR DESCRIPTION
| CMake Error at .../CMakeLists.txt (qt5_use_modules):
|   Unknown CMake command "qt5_use_modules".

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>